### PR TITLE
Fix point_in_polygon bug in vertical edge handling

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -13,20 +13,15 @@ def point_in_polygon(x, y, poly):
     Check if the point (x, y) lies within the polygon defined by a list of (x, y) tuples.
     Uses the ray-casting algorithm.
     """
-    num = len(poly)
+    n = len(poly)
     inside = False
-    p1x, p1y = poly[0]
-    for i in range(1, num + 1):
-        p2x, p2y = poly[i % num]
-        if y > min(p1y, p2y):
-            if y <= max(p1y, p2y):
-                if p1y != p2y:
-                    xinters = (y - p1y) * (p2x - p1x) / (p2y - p1y) + p1x
-                else:
-                    xinters = p1x
-                if p1x == p2x or x <= xinters:
-                    inside = not inside
-        p1x, p1y = p2x, p2y
+    j = n - 1
+    for i in range(n):
+        xi, yi = poly[i]
+        xj, yj = poly[j]
+        if ((yi > y) != (yj > y)) and (x < (xj - xi) * (y - yi) / (yj - yi) + xi):
+            inside = not inside
+        j = i
     return inside
 
 def evaluate_answer(ground_truth, generated_answer):


### PR DESCRIPTION
## **Description**

In the current implementation (line 27), the condition:
```python3
  if p1x == p2x or x <= xinters:
      inside = not inside
```

  When an edge on the left is vertical (p1x == p2x), the function toggles inside regardless of the point's x-coordinate. This violates the ray-casting algorithm, which should only count edge crossings to the right of the test point.


##  **Reproduction**
``` python3
  polygon = [(0.2, 0.3), (0.8, 0.3), (0.8, 0.9), (0.2, 0.9)]  # axis-aligned rectangle
  point = (0.5, 0.6)  # clearly inside

  point_in_polygon(0.5, 0.6, polygon)
  # Current: False (incorrect)
  # Expected: True
```
and,

``` python3
polygon = [(0.2, 0.3), (0.8, 0.3), (0.7, 0.9), (0.2, 0.9)]  # left axis-aligned rectangle 
point = (0.5, 0.6)  # clearly inside

point_in_polygon(0.5, 0.6, polygon)
# Current: False (incorrect)
# Expected: True
```


## **Root Cause Analysis**

  For the rectangle above with center point (0.5, 0.6):
  - Right vertical edge (x=0.8): Correctly toggles inside to True
  - Left vertical edge (x=0.2): Incorrectly toggles inside back to False because p1x == p2x short-circuits the x <= xinters check

  The left edge should not be counted since it's to the left of the test point (0.5 > 0.2).


## **Impact**

  On RoboSpatial-Home Context split (122 samples):
  - 3 samples (2.46%) return incorrect results when testing polygon centroids

## **Fix**
  Replace the standard ray-casting implementation:
``` python3
  def point_in_polygon(x, y, poly):
      n = len(poly)
      inside = False
      j = n - 1
      for i in range(n):
          xi, yi = poly[i]
          xj, yj = poly[j]
          if ((yi > y) != (yj > y)) and (x < (xj - xi) * (y - yi) / (yj - yi) + xi):
              inside = not inside
          j = i
      return inside
```

## **Testing**

``` python3
  def test_point_in_polygon():
      # Axis-aligned rectangle (contains vertical edges)
      rect = [(0.2, 0.3), (0.8, 0.3), (0.8, 0.9), (0.2, 0.9)]

      assert point_in_polygon(0.5, 0.6, rect) == True   # center
      assert point_in_polygon(0.3, 0.5, rect) == True   # inside left
      assert point_in_polygon(0.7, 0.5, rect) == True   # inside right
      assert point_in_polygon(0.1, 0.5, rect) == False  # outside left
      assert point_in_polygon(0.9, 0.5, rect) == False  # outside right

      # Triangle without vertical edges (works in both versions)
      triangle = [(0.3, 0.2), (0.7, 0.5), (0.4, 0.8)]
      assert point_in_polygon(0.5, 0.5, triangle) == True
      assert point_in_polygon(0.1, 0.5, triangle) == False
```